### PR TITLE
Format rethink

### DIFF
--- a/Dmg_Calc_Instance.py
+++ b/Dmg_Calc_Instance.py
@@ -32,8 +32,8 @@ class Build:
                 print("Base HP: ", c.base_hp())
                 print("Base ATK: ", c.base_atk())
                 print("Base DEF: ", c.base_def())
-                print(f"Crit Rate:  {c.cr()*100:.1f}%")
-                print(f"Crit Damage:  {c.cd()*100:.1f}%")
+                print(f"Crit Rate:  {c.stat('cr')*100:.1f}%")
+                print(f"Crit Damage:  {c.stat('cd')*100:.1f}%")
                 print("----------------------------")
 
     def display_weapon(self) -> None:
@@ -66,8 +66,8 @@ Character:  {character.info.name}
     Base HP:        {character.base_hp()}
     Base DEF:       {character.base_def()}
     Base ATK:       {character.base_atk()}
-    Crit Rate:      {character.cr()*100:.1f}%
-    Crit Damage:    {character.cd()*100:.1f}%
+    Crit Rate:      {character.stat('cr')*100:.1f}%
+    Crit Damage:    {character.stat('cd')*100:.1f}%
     Weapon:         {character.weapon.info.name}
         Weapon Type:    {character.weapon.info.type}
         Base Attack:    {character.weapon.base_atk()}

--- a/data/character/rover-spectro.json
+++ b/data/character/rover-spectro.json
@@ -170,5 +170,64 @@
             "strikes": 1,
             "after": ["(fe)1a"]
         }
-    }
+    },
+    "resonance_chain": [
+        {
+            "name": "Odyssey of Beginnings",
+            "buff": {
+                "id": "odyssey-of-beginnings",
+                "stat": "cr",
+                "amount": 0.15,
+                "target": "self",
+                "after": [
+                    {"move": "e"},
+                    {"move": "(f)e"}
+                ]
+            }
+        },
+        {
+            "name": "Microcosmic Murmurs",
+            "buff": {
+                "id": "microcosmic-murmurs",
+                "stat": "spectro_dmg_bonus",
+                "amount": 0.20,
+                "target": "self"
+            }
+        },
+        {
+            "name": "Visages of Dust",
+            "buff": {
+                "id": "visages-of-dust",
+                "stat": "er",
+                "amount": 0.20,
+                "target": "self"
+            }
+        },
+        {
+            "name": "Resonating Lamella",
+            "buff": null
+        },
+        {
+            "name": "Temporal Virtuoso",
+            "buff": {
+                "id": "temporal-virtuoso",
+                "stat": "q_dmg_bonus",
+                "amount": 0.40,
+                "target": "self"
+            }
+        },
+        {
+            "name": "Echoes of Wanderlust",
+            "buff": {
+                "id": "echoes-of-wanderlust",
+                "stat": "spectro_dmg_res",
+                "amount": 0.10,
+                "target": "enemy",
+                "after": [
+                    {"move": "e"},
+                    {"move": "(f)e"}
+                ]
+            }
+        }
+    ]
 }

--- a/data/character/rover-spectro.json
+++ b/data/character/rover-spectro.json
@@ -12,150 +12,163 @@
         "atk": [ 30,  100.53,  173.59,  221.38,  269.16,  309.44,   349.72,   375.00],
         "def": [112,  359.92,  617.09,  781.96,  946.85, 1111.72,  1276.60,  1368.89]
     },
-    "max_forte": 100,
+    "max_fe": 100,
     "moves": {
-        "multipliers": {
-            "1a":      [29.75,   32.19,  34.63,  38.05,  40.49,  43.29,  47.20,  51.10,  55.00,  59.15],
-            "2a":      [38.25,   41.39,  44.53,  48.92,  52.06,  55.66,  60.68,  65.70,  70.72,  76.05],
-            "3a":      [ 7.65,    8.28,   8.91,   9.79,  10.42,  11.14,  12.14,  13.14,  14.15,  15.21],
-            "4a":      [65.45,   70.82,  76.19,  83.70,  89.07,  95.24, 103.83, 112.42, 121.00, 130.13],
-            "h":       [ 9.69,   10.49,  11.28,  12.40,  13.19,  14.10,  15.38,  16.65,  17.92,  19.27],
-            "(3at)a":  [38.25,   41.39,  44.53,  48.92,  52.06,  55.66,  60.68,  65.70,  70.72,  76.05],
-            "(3ata)a": [63.75,   68.98,  74.21,  81.53,  86.76,  92.77, 101.13, 109.50, 117.86, 126.75],
-            "p":       [52.70,   57.03,  61.35,  67.40,  71.72,  76.69,  83.60,  90.52,  97.43, 104.78],
-            "(d)a":    [98.25,  106.31, 114.37, 125.65, 133.70, 142.97, 155.86, 168.75, 181.64, 195.34],
-            "e":       [118.80, 128.55, 138.29, 151.93, 161.67, 172.87, 188.46, 204.04, 219.63, 236.19],
-            "r@1":     [100.00, 108.20, 116.40, 127.88, 136.08, 145.51, 158.63, 171.75, 182.87, 198.81],
-            "r@2":     [340.00, 367.88, 395.76, 434.80, 462.68, 494.74, 539.35, 583.95, 628.56, 675.96],
-            "i":       [ 85.00,  91.97,  98.94, 108.70, 115.67, 123.69, 134.84, 145.99, 157.14, 168.99],
-            "(f)e":    [ 64.93,  70.25,  75.58,  83.03,  88.35,  94.48, 103.00, 111.51, 120.03, 129.08],
-            "(f)e@2":  [ 20.00,  21.64,  23.28,  25.58,  27.22,  29.11,  31.73,  34.35,  36.98,  39.77],
-            "(fe)1a":  [ 40.00,  43.28,  46.56,  51.16,  54.44,  58.21,  63.46,  68.70,  73.95,  79.53],
-            "(fe)2a":  [ 80.00,  86.56,  93.12, 102.31, 108.87, 116.41, 126.91, 137.40, 147.90, 159.05]
+        "1a": {
+            "name": "Basic Attack Part 1",
+            "forte_scaling": [29.75, 32.19, 34.63, 38.05, 40.49, 43.29, 47.20, 51.10, 55.00, 59.15],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": null
         },
-        "meta": {
-            "1a": {
-                "name": "Basic Attack Part 1",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": null
-            },
-            "2a": {
-                "name": "Basic Attack Part 2",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["1a"]
-            },
-            "3a": {
-                "name": "Basic Attack Part 3",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 5,
-                "after": ["2a"]
-            },
-            "4a": {
-                "name": "Basic Attack Part 4",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["3a"]
-            },
-            "h": {
-                "name": "Heavy Attack",
-                "forte_type": "a",
-                "move_type": "h",
-                "strikes": 5,
-                "after": null
-            },
-            "(3at)a": {
-                "name": "Heavy Attack: Resonance",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["3a", "h"]
-            },
-            "(3ata)a": {
-                "name": "Heavy Attack: Aftertune",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["(3at)a", "(d)a"]
-            },
-            "p": {
-                "name": "Mid-air Attack",
-                "forte_type": "a",
-                "move_type": "p",
-                "strikes": 1,
-                "after": ["(3at)a", "(d)a"]
-            },
-            "(d)a": {
-                "name": "Dodge counter",
-                "forte_type": "a",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["d"]
-            },
-            "e": {
-                "name": "Resonance skill: Resonating Slashes",
-                "forte_type": "e",
-                "move_type": "e",
-                "strikes": 1,
-                "after": null
-            },
-            "r@1": {
-                "name": "Resonance Liberation: Echoing Orchestra (first hit)",
-                "forte_type": "r",
-                "move_type": "r",
-                "strikes": 1,
-                "after": null,
-                "chain": "r@2"
-            },
-            "r@2": {
-                "name": "Resonance Liberation: Echoing Orchestra (second hit)",
-                "forte_type": "r",
-                "move_type": "r",
-                "strikes": 1,
-                "after": null
-            },
-            "i": {
-                "name": "Intro Skill: Reticence",
-                "forte_type": "i",
-                "move_type": "i",
-                "strikes": 1,
-                "after": null
-            },
-            "(f)e": {
-                "name": "Resonance Skill: Resonating Spin",
-                "forte_type": "f",
-                "move_type": "e",
-                "fe_req": 50,
-                "strikes": 1,
-                "after": null,
-                "chain": "(f)e@2"
-            },
-            "(f)e@2": {
-                "name": "Resonance Skill: Resonating Whirl",
-                "forte_type": "f",
-                "move_type": "e",
-                "strikes": 2,
-                "after": null
-            },
-            "(fe)1a": {
-                "name": "Basic Attack: Resonating Echoes Part 1",
-                "forte_type": "f",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["(f)e"]
-            },
-            "(fe)2a": {
-                "name": "Basic Attack: Resonating Echoes Part 2",
-                "forte_type": "f",
-                "move_type": "a",
-                "strikes": 1,
-                "after": ["(fe)1a"]
-            }
+        "2a": {
+            "name": "Basic Attack Part 2",
+            "forte_scaling": [38.25, 41.39, 44.53, 48.92, 52.06, 55.66, 60.68, 65.70, 70.72, 76.05],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["1a"]
+        },
+        "3a": {
+            "name": "Basic Attack Part 3",
+            "forte_scaling": [ 7.65, 8.28, 8.91, 9.79, 10.42, 11.14, 12.14, 13.14, 14.15, 15.21],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 5,
+            "after": ["2a"]
+        },
+        "4a": {
+            "name": "Basic Attack Part 4",
+            "forte_scaling": [65.45, 70.82, 76.19, 83.70, 89.07, 95.24, 103.83, 112.42, 121.00, 130.13],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["3a"]
+        },
+        "h": {
+            "name": "Heavy Attack",
+            "forte_scaling": [ 9.69, 10.49, 11.28, 12.40, 13.19, 14.10, 15.38, 16.65, 17.92, 19.27],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "h",
+            "strikes": 5,
+            "after": null
+        },
+        "(3at)a": {
+            "name": "Heavy Attack: Resonance",
+            "forte_scaling":  [38.25, 41.39, 44.53, 48.92, 52.06, 55.66, 60.68, 65.70, 70.72, 76.05],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["3a", "h"]
+        },
+        "(3ata)a": {
+            "name": "Heavy Attack: Aftertune",
+            "forte_scaling": [63.75, 68.98, 74.21, 81.53, 86.76, 92.77, 101.13, 109.50, 117.86, 126.75],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["(3at)a", "(d)a"]
+        },
+        "p": {
+            "name": "Mid-air Attack",
+            "forte_scaling": [52.70, 57.03, 61.35, 67.40, 71.72, 76.69, 83.60, 90.52, 97.43, 104.78],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "p",
+            "strikes": 1,
+            "after": ["(3at)a", "(d)a"]
+        },
+        "(d)a": {
+            "name": "Dodge counter",
+            "forte_scaling": [98.25, 106.31, 114.37, 125.65, 133.70, 142.97, 155.86, 168.75, 181.64, 195.34],
+            "forte_type": "a",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["d"]
+        },
+        "e": {
+            "name": "Resonance skill: Resonating Slashes",
+            "forte_scaling": [118.80, 128.55, 138.29, 151.93, 161.67, 172.87, 188.46, 204.04, 219.63, 236.19],
+            "forte_type": "e",
+            "stat_scaling": "atk",
+            "move_type": "e",
+            "strikes": 1,
+            "after": null
+        },
+        "r@1": {
+            "name": "Resonance Liberation: Echoing Orchestra (first hit)",
+            "forte_scaling": [100.00, 108.20, 116.40, 127.88, 136.08, 145.51, 158.63, 171.75, 182.87, 198.81],
+            "forte_type": "r",
+            "stat_scaling": "atk",
+            "move_type": "r",
+            "strikes": 1,
+            "after": null,
+            "chain": "r@2"
+        },
+        "r@2": {
+            "name": "Resonance Liberation: Echoing Orchestra (second hit)",
+            "forte_scaling": [340.00, 367.88, 395.76, 434.80, 462.68, 494.74, 539.35, 583.95, 628.56, 675.96],
+            "forte_type": "r",
+            "stat_scaling": "atk",
+            "move_type": "r",
+            "strikes": 1,
+            "after": null
+        },
+        "i": {
+            "name": "Intro Skill: Reticence",
+            "forte_scaling": [ 85.00, 91.97, 98.94, 108.70, 115.67, 123.69, 134.84, 145.99, 157.14, 168.99],
+            "forte_type": "i",
+            "stat_scaling": "atk",
+            "move_type": "i",
+            "strikes": 1,
+            "after": null
+        },
+        "(f)e": {
+            "name": "Resonance Skill: Resonating Spin",
+            "forte_scaling": [ 64.93, 70.25, 75.58, 83.03, 88.35, 94.48, 103.00, 111.51, 120.03, 129.08],
+            "forte_type": "f",
+            "stat_scaling": "atk",
+            "move_type": "e",
+            "fe_req": 50,
+            "strikes": 1,
+            "after": null,
+            "chain": "(f)e@2"
+        },
+        "(f)e@2": {
+            "name": "Resonance Skill: Resonating Whirl",
+            "forte_scaling": [ 20.00, 21.64, 23.28, 25.58, 27.22, 29.11, 31.73, 34.35, 36.98, 39.77],
+            "forte_type": "f",
+            "stat_scaling": "atk",
+            "move_type": "e",
+            "strikes": 2,
+            "after": null
+        },
+        "(fe)1a": {
+            "name": "Basic Attack: Resonating Echoes Part 1",
+            "forte_scaling": [ 40.00, 43.28, 46.56, 51.16, 54.44, 58.21, 63.46, 68.70, 73.95, 79.53],
+            "forte_type": "f",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["(f)e"]
+        },
+        "(fe)2a": {
+            "name": "Basic Attack: Resonating Echoes Part 2",
+            "forte_scaling":  [ 80.00, 86.56, 93.12, 102.31, 108.87, 116.41, 126.91, 137.40, 147.90, 159.05],
+            "forte_type": "f",
+            "stat_scaling": "atk",
+            "move_type": "a",
+            "strikes": 1,
+            "after": ["(fe)1a"]
         }
     }
 }

--- a/data/character/rover-spectro.json
+++ b/data/character/rover-spectro.json
@@ -1,5 +1,4 @@
 {
-    "$schema": "https://raw.githubusercontent.com/Alyminya/WuWa-DMG-Calc-WiP/main/data/_schemas/character.schema.json",
     "id": "rover-spectro",
     "name": "Rover-Spectro",
     "rarity": 5,

--- a/data/character/temp/chixia.json
+++ b/data/character/temp/chixia.json
@@ -14,7 +14,7 @@
        "def": [78.00, 250.66, 429.76, 544.58, 659.41, 774.24, 889.06, 953.33] 
     },
     "max_forte": 70,
-    "moves": {
+    "attacks": {
         "multipliers": {
             "1a": [33.30, 36.04, 38.77, 42.59, 45.32, 48.46, 52.83, 57.20, 61.57, 66.21],
             "2a": [24.30, 26.30, 28.29, 31.08, 33.07, 35.36, 38.55, 41.74, 44.93, 48.32],
@@ -36,7 +36,7 @@
             "1a": {
                 "name": "Basic Attack: POW POW part 1",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "fe_yield": 1,
                 "after": null
@@ -44,7 +44,7 @@
             "2a": {
                 "name": "Basic Attack: POW POW part 2",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 2,
                 "fe_yield": 1,
                 "after": ["1a"]
@@ -52,7 +52,7 @@
             "3a": {
                 "name": "Basic Attack: POW POW part 3",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 4,
                 "fe_yield": 1,
                 "after": ["2a"]
@@ -60,7 +60,7 @@
             "4a": {
                 "name": "Basic Attack: POW POW part 4",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "fe_yield": 1,
                 "after": ["3a"]
@@ -68,35 +68,35 @@
             "h": {
                 "name": "Heavy Attack",
                 "forte_type": "a",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 1,
                 "after": null
             },
             "(c)h": {
                 "name": "Fully Charged Heavy Attack",
                 "forte_type": "a",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 1,
                 "after": null
             },
             "p": {
                 "name": "Mid-Air Attack",
                 "forte_type": "a",
-                "move_type": "p",
+                "atk_type": "p",
                 "strikes": 1,
                 "after": null
             },
             "(d)a": {
                 "name": "Dodge Counter",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["d"]
             },
             "e": {
                 "name": "Resonance Skill: Whizzing Fight Spirit",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 8,
                 "fe_yield": 25,
                 "after": null
@@ -104,7 +104,7 @@
             "r@1": {
                 "name": "Resonance Liberation: Blazing Flames part 1",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 1,
                 "after": null,
                 "chain": "r@2"
@@ -112,14 +112,14 @@
             "r@2": {
                 "name": "Resonance Liberation: Blazing Flames part 2",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 11,
                 "after": ["r@1"]
             },
             "i@1": {
                 "name": "Intro Skill: Grand Entrance part 1",
                 "forte_type": "i",
-                "move_type": "i",
+                "atk_type": "i",
                 "strikes": 2,
                 "fe_yield": 1,
                 "after": null,
@@ -128,14 +128,14 @@
             "i@2": {
                 "name": "Intro Skill: Grand Entrance part 2",
                 "forte_type": "i",
-                "move_type": "i",
+                "atk_type": "i",
                 "strikes": 4,
                 "after": ["i@1"]
             },
             "(f)e": {
                 "name": "Forte Circuit: Heroic Bullets - Thermobaric Bullets",
                 "forte_type": "f",
-                "move_type": "e",
+                "atk_type": "e",
                 "fe_req": 1,
                 "strikes": 1,
                 "after": ["4a"]
@@ -143,7 +143,7 @@
             "(f)a": {
                 "name": "Forte Circuit: Heroic Bullets - Boom Boom",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "fe_req": 1,
                 "strikes": 1,
                 "after": null

--- a/data/character/temp/danjin.json
+++ b/data/character/temp/danjin.json
@@ -14,7 +14,7 @@
         "def": [ 94.00,  302.08,  517.91,  656.29,  794.68,  933.05, 1071.43, 1148.89]
     },
     "max_forte": 120,
-    "moves": {
+    "attacks": {
         "multipliers": {
             "1a":    [28.80,   31.17,  33.53,  36.83,  39.20,  41.91,  45.69,  49.47,  53.25,  57.26],
             "2a":    [29.60,   32.03,  34.46,  37.86,  40.28,  43.08,  46.96,  50.84,  54.73,  58.85],
@@ -40,28 +40,28 @@
             "1a": {
                 "name": "Basic Attack Part 1",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": null
             },
             "2a": {
                 "name": "Basic Attack Part 2",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["1a", "e"]
             },
             "3a": {
                 "name": "Basic Attack Part 3",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["2a"]
             },
             "h": {
                 "name": "Heavy Attack",
                 "forte_type": "a",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 3,
                 "stamina": 20,
                 "after": null
@@ -69,7 +69,7 @@
             "p": {
                 "name": "Mid-Air Attack",
                 "forte_type": "a",
-                "move_type": "p",
+                "atk_type": "p",
                 "strikes": 1,
                 "stamina": 30,
                 "after": null
@@ -77,14 +77,14 @@
             "(d)a": {
                 "name": "Dodge Counter",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 3,
                 "after": ["d"]
             },
             "e": {
                 "name": "Resonance Skill: Carmine Gleam",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 2,
                 "fe_yield": 12,
                 "after": null
@@ -92,7 +92,7 @@
             "1e": {
                 "name": "Resonance Skill: Crimson Erosion Part 1",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 2,
                 "fe_yield": 12,
                 "after": ["2a"]
@@ -100,7 +100,7 @@
             "2e": {
                 "name": "Resonance Skill: Crimson Erosion Part 2",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 2,
                 "fe_yield": 12,
                 "after": ["1e"]
@@ -108,7 +108,7 @@
             "1E": {
                 "name": "Resonance Skill: Sanguine Pulse Part 1",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 2,
                 "fe_yield": 12,
                 "after": ["3a"]
@@ -116,7 +116,7 @@
             "2E": {
                 "name": "Resonance Skill: Sanguine Pulse Part 2",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 3,
                 "fe_yield": 12,
                 "after": ["1E"]
@@ -124,7 +124,7 @@
             "3E": {
                 "name": "Resonance Skill: Sanguine Pulse Part 3",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 3,
                 "fe_yield": 12,
                 "after": ["2E"]
@@ -132,7 +132,7 @@
             "r": {
                 "name": "Resonance Liberation: Crimson Bloom",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 8,
                 "after": null,
                 "chain": "(r)r"
@@ -140,21 +140,21 @@
             "(r)r": {
                 "name": "Resonance Liberation: Scatterbloom",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 1,
                 "after": []
             },
             "i": {
                 "name": "Intro Skill: Vindiction",
                 "forte_type": "i",
-                "move_type": "i",
+                "atk_type": "i",
                 "strikes": 4,
                 "after": null
             },
             "(f)h": {
                 "name": "Heavy Attack: Chaoscleave",
                 "forte_type": "f",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 7,
                 "fe_req": 60,
                 "after": null
@@ -162,14 +162,14 @@
             "(fh)a": {
                 "name": "Heavy Attack: Scatterbloom",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["(f)h"]
             },
             "(f)H": {
                 "name": "Heavy Attack: Chaoscleave (full energy)",
                 "forte_type": "f",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 7,
                 "fe_req": 120,
                 "after": null
@@ -177,7 +177,7 @@
             "(fH)a": {
                 "name": "Heavy Attack: Scatterbloom (full energy)",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["(f)H"]
             }

--- a/data/character/temp/taoqi.json
+++ b/data/character/temp/taoqi.json
@@ -14,7 +14,7 @@
         "def": [125.00, 411.34, 705.24, 893.67, 1082.11, 1270.54, 1458.97, 1564.44]
     },
     "max_forte": 3,
-    "moves": {
+    "attacks": {
         "multipliers": {
             "1a": [45.34, 49.06, 52.78, 57.99, 61.70, 65.98, 71.93, 77.83, 83.83, 90.15],
             "2a": [42.67, 46.17, 49.67, 54.57, 58.07, 62.09, 67.69, 73.29, 78.89, 84.84],
@@ -36,91 +36,91 @@
             "1a": {
                 "name": "Basic Attack Part 1",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": null
             },
             "2a": {
                 "name": "Basic Attack Part 2",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["1a"]
             },
             "3a": {
                 "name": "Basic Attack Part 3",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["2a"]
             },
             "4a": {
                 "name": "Basic Attack Part 4",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["3a"]
             },
             "h": {
                 "name": "Heavy Attack",
                 "forte_type": "a",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 1,
                 "after": null
             },
             "sp": {
                 "name": "Basic Attack: Strategic Parry",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": null
             },
             "p": {
                 "name": "Mid-Air Attack",
                 "forte_type": "a",
-                "move_type": "p",
+                "atk_type": "p",
                 "strikes": 1,
                 "after": null
             },
             "(d)a": {
                 "name": "Dodge Counter",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["d"]
             },
             "e": {
                 "name": "Resonance Skill: Rocksteady Defence",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 1,
                 "after": null
             },
             "e@h": {
                 "name": "Resonance Skill: Rocksteady Defence (healing)",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 0,
                 "after": null
             },
             "r": {
                 "name": "Resonance Liberation: Unmovable",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 1,
                 "after": null
             },
             "i": {
                 "name": "Intro Skill: Defence Formation",
                 "forte_type": "i",
-                "move_type": "i",
+                "atk_type": "i",
                 "strikes": 1,
                 "after": null
             },
             "(f)ta1": {
                 "name": "Basic Attack: Timed Counters Part 1",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "fe_req": 1,
                 "strikes": 1,
                 "after": ["sp", "i"]
@@ -128,7 +128,7 @@
             "(f)ta2": {
                 "name": "Basic Attack: Timed Counters Part 2",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "fe_req": 1,
                 "strikes": 1,
                 "after": ["(f)t1"]
@@ -136,7 +136,7 @@
             "(f)ta3": {
                 "name": "Basic Attack: Timed Counters Part 3",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "fe_req": 1,
                 "strikes": 1,
                 "after": ["(f)t2"]

--- a/data/character/temp/yangyang.json
+++ b/data/character/temp/yangyang.json
@@ -14,7 +14,7 @@
        "def": [90.00, 289.22, 495.87, 628.36, 760.86, 893.35, 1025.84, 1100.00] 
     },
     "max_forte": 3,
-    "moves": {
+    "attacks": {
         "multipliers": {
             "1a":[22.50, 24.34, 26.18, 28.77, 30.61, 32.73, 35.69, 38.64, 41.59, 44.73],
             "2a":[30.00, 32.46, 34.92, 38.36, 40.82, 43.65, 47.58, 51.52, 55.46, 59.64],
@@ -38,28 +38,28 @@
             "1a": {
                 "name": "Basic Attack: Part 1",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": null
             },
             "2a": {
                 "name": "Basic Attack: Part 2",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["1a"]
             },
             "3a": {
                 "name": "Basic Attack: Part 3",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["2a"]
             },
             "4a@1": {
                 "name": "Basic Attack: Part 4 (strike 1)",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 2,
                 "after": ["3a"],
                 "chain": "4a@2"
@@ -67,42 +67,42 @@
             "4a@2": {
                 "name": "Basic Attack: Part 4 (strike 2)",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["4a@1"]
             },
             "h": {
                 "name": "Heavy Attack",
                 "forte_type": "a",
-                "move_type": "h",
+                "atk_type": "h",
                 "strikes": 3,
                 "after": null
             },
             "p": {
                 "name": "Mid-Air Attack",
                 "forte_type": "a",
-                "move_type": "p",
+                "atk_type": "p",
                 "strikes": 1,
                 "after": null
             },
             "(h)a": {
                 "name": "Heavy Attack: Zephyr Song",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 1,
                 "after": ["h", "(d)a"]  
             },
             "(d)a": {
                 "name": "Dodge Counter",
                 "forte_type": "a",
-                "move_type": "a",
+                "atk_type": "a",
                 "strikes": 2,
                 "after": ["d"]
             },
             "e@1": {
                 "name": "Resonance Skill: Zephyr Domain",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 4,
                 "after": null,
                 "chain": "e@2"
@@ -110,14 +110,14 @@
             "e@2": {
                 "name": "Resonance Skill: Zephyr Domain (last hit)",
                 "forte_type": "e",
-                "move_type": "e",
+                "atk_type": "e",
                 "strikes": 1,
                 "after": ["e@1"]
             },
             "r@1": {
                 "name": "Resonance Liberation: Wind Spirals",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 12,
                 "after": null,
                 "chain": "r@2"
@@ -125,21 +125,21 @@
             "r@2": {
                 "name": "Resonance Liberation: Wind Spirals (last hit)",
                 "forte_type": "r",
-                "move_type": "r",
+                "atk_type": "r",
                 "strikes": 1,
                 "after": ["r@1"]
             },
             "i": {
                 "name": "Intro Skill: Cerulean Song",
                 "forte_type": "i",
-                "move_type": "i",
+                "atk_type": "i",
                 "strikes": 2,
                 "after": null
             },
             "(f)h": {
                 "name": "Heavy Attack: Stormy Strike",
                 "forte_type": "f",
-                "move_type": "h",
+                "atk_type": "h",
                 "fe_req": 3,
                 "strikes": 2,
                 "after": null
@@ -147,7 +147,7 @@
             "(f)ma@1": {
                 "name": "Mid-Air Attack: Feather Release",
                 "forte_type": "f",
-                "move_type": "p",
+                "atk_type": "p",
                 "fe_req": 3,
                 "strikes": 5,
                 "after": null,
@@ -156,7 +156,7 @@
             "(f)ma@2": {
                 "name": "Mid-Air Attack: Feather Release (last 2 hits)",
                 "forte_type": "f",
-                "move_type": "a",
+                "atk_type": "a",
                 "fe_req": 3,
                 "strikes": 2,
                 "after": ["(f)ma@1"]

--- a/data/characters.json
+++ b/data/characters.json
@@ -1,7 +1,3 @@
 {
-    "danjin": "character/danjin.json",
-    "rover-spectro": "character/rover-spectro.json",
-    "taoqi": "character/taoqi.json",
-    "yangyang": "character/yangyang.json",
-    "chixia": "character/chixia.json"
+    "rover-spectro": "character/rover-spectro.json"
 }

--- a/dmg_calc_instance_tester.json
+++ b/dmg_calc_instance_tester.json
@@ -4,14 +4,14 @@
             "level": 90,
             "weapon": {
                 "weapon_id": "training-sword",
-                "level": 70   
+                "level": 1
             },
             "forte_levels": {
-                "a": 10,
-                "e": 10,
-                "f": 10,
-                "r": 10,
-                "i": 10
+                "a": 1,
+                "e": 1,
+                "f": 1,
+                "r": 1,
+                "i": 1
             },
             "echo_set_bonus": [5],
             "echo_sets": ["lingering-tunes"],

--- a/ruff.toml
+++ b/ruff.toml
@@ -22,7 +22,6 @@ select = [
     "UP005", # 	{alias} is deprecated, use {target}
     "UP006", # Use {to} instead of {from} for type annotation
     "UP040", # Type alias {name} uses {type_alias_method} instead of the type keyword
-    "UP007", # Use X | Y for type annotations
     "ANN001", # Missing type annotation for function argument {name}
     "ANN002", # Missing type annotation for *{name}
     "ANN003", # Missing type annotation for **{name}

--- a/util/character.py
+++ b/util/character.py
@@ -40,7 +40,7 @@ class Character:
     def move_multiplier(self, move_id: str) -> float:
         move = self.info.moves[move_id]
         move_level = self.forte_levels[move.forte_type]
-        multiplier = self.info.move_multipliers[move_id][move_level-1]/100.0
+        multiplier = self.info.moves[move_id].forte_scaling[move_level-1]/100.0
         return multiplier
 
     def __str__(self) -> str:

--- a/util/character.py
+++ b/util/character.py
@@ -28,11 +28,39 @@ class Character:
     def base_atk(self) -> float:
         return self.info.base_atk_scaling[self.ascension()]
 
-    def cr(self) -> float:
-        return 0.05
-    
-    def cd(self) -> float:
-        return 1.50
+    def stat(self, stat: db.Stat, after: str|None = None) -> float:
+        base_value = 0.0
+        match stat:
+            case 'cr': base_value = 0.05
+            case 'cd': base_value = 1.50
+        bonus_value = 0.0
+        for sn in self.info.res_chain:
+            if sn.buff is None: continue
+            buff = sn.buff
+            if buff.target != "self": continue
+            if buff.stat != stat: continue
+            conditions_satisfied = True
+            if buff.after is not None:
+                for cond in buff.after:
+                    if cond.move is not None and (after is None or cond.move != after):
+                        conditions_satisfied = False
+                        break
+            if not conditions_satisfied:
+                continue
+            bonus_value += buff.amount
+        total_value = base_value + bonus_value
+        return total_value
+
+    def em_bonus(self, after: str|None = None) -> float:
+        em_bonus_stat: db.Stat
+        match self.info.element:
+            case 'glacio':  em_bonus_stat = 'glacio_dmg_bonus'
+            case 'fusion':  em_bonus_stat = 'fusion_dmg_bonus'
+            case 'electro': em_bonus_stat = 'electro_dmg_bonus'
+            case 'aero':    em_bonus_stat = 'aero_dmg_bonus'
+            case 'spectro': em_bonus_stat = 'spectro_dmg_bonus'
+            case 'havoc':   em_bonus_stat = 'havoc_dmg_bonus'
+        return self.stat(em_bonus_stat, after)
 
     def moves(self) -> dict[str, db.Move]:
         return self.info.moves
@@ -46,5 +74,5 @@ class Character:
     def __str__(self) -> str:
         """String representation of the character."""
         return (f"Character({self.info.name}, Level: {self.level}, Base HP: {self.base_hp()}, "
-                f"Base ATK: {self.base_atk()}, Base DEF: {self.base_def()}, Crit Rate: {self.cr()*100}%, "
-                f"Crit Damage: {self.cd()*100}%)")
+                f"Base ATK: {self.base_atk()}, Base DEF: {self.base_def()}, Crit Rate: {self.stat('cr')*100}%, "
+                f"Crit Damage: {self.stat('cd')*100}%)")

--- a/util/db/db.py
+++ b/util/db/db.py
@@ -48,18 +48,19 @@ def load_db() -> model.DB:
         character.base_atk_scaling = character_data['stats']['atk']
         character.base_hp_scaling = character_data['stats']['hp']
         character.base_def_scaling = character_data['stats']['def']
-        character.max_forte = character_data['max_forte']
+        character.max_fe = character_data['max_fe']
         character.weapon = character_data['weapon']
         character.element = character_data['element']
-        character.move_multipliers = character_data['moves']['multipliers']
-        move_meta = character_data['moves']['meta']
+        move_meta = character_data['moves']
         character.moves = {}
         for move_id in move_meta:
             meta = move_meta[move_id]
             move = model.Move()
             move.id = move_id
             move.name = meta['name']
+            move.forte_scaling = meta['forte_scaling']
             move.forte_type = meta['forte_type']
+            move.stat_scaling = meta['stat_scaling']
             move.move_type = meta['move_type']
             move.strikes = meta['strikes']
             move.after = meta['after']

--- a/util/db/db.py
+++ b/util/db/db.py
@@ -2,7 +2,6 @@
 import os.path
 import json
 from . import model
-import jsonschema
 from typing import Any, Callable
 
 DB_PATH = './data'
@@ -26,9 +25,6 @@ fp_characters_schema = os.path.join(DB_PATH, SCHEMA_PATH, CHARACTERS_SCHEMA)
 def load_validate_json(json_path: str, json_schema_path: str) -> dict[str, Any]:
     with open(json_path, mode='r') as data_file:
         data = json.load(data_file)
-    with open(json_schema_path, mode='r') as schema_file:
-        schema = json.load(schema_file)
-    jsonschema.validate(data, schema)
     return data
 
 def opt_field[T,U](cls: Callable[[Any], T], data: dict[str, Any], key: str, default: U) -> T|U:

--- a/util/db/db.py
+++ b/util/db/db.py
@@ -70,6 +70,28 @@ def load_db() -> model.DB:
             move.sta_req = opt_field(int, meta, 'stamina', None) # TODO(flysand): rename the field
             move.con_yield = opt_field(int, meta, 'con_yield', None)
             character.moves[move_id] = move
+        resonance_chain_meta: list[dict[str, Any]] = character_data['resonance_chain']
+        rc: list[model.Sequence_Node] = []
+        for seq_node in resonance_chain_meta:
+            seq = model.Sequence_Node()
+            seq.name = seq_node['name']
+            if 'buff' in seq_node and seq_node['buff'] is not None:
+                seq.buff = model.Buff()
+                seq.buff.id = seq_node['buff']['id']
+                seq.buff.stat = seq_node['buff']['stat']
+                seq.buff.amount = seq_node['buff']['amount']
+                seq.buff.target = seq_node['buff']['target']
+                conditions: list[model.Buff_Condition] = []
+                if 'after' in seq_node['buff']:
+                    for cond_data in seq_node['buff']['after']:
+                        cond = model.Buff_Condition()
+                        cond.move = cond_data['move']
+                        conditions.append(cond)
+                seq.buff.after = conditions
+            else:
+                seq.buff = None
+            rc.append(seq)
+        character.res_chain = rc
         db.characters[character.id] = character
     db.weapons = {}
     weapons_data = load_validate_json(fp_weapons_data, fp_weapons_schema)

--- a/util/db/model.py
+++ b/util/db/model.py
@@ -43,7 +43,9 @@ Substat = \
 class Move:
     id: str
     name: str
+    forte_scaling: list[float]
     forte_type: Forte_Type
+    stat_scaling: str
     move_type: Move_Type
     strikes: int
     after: list[str]|None
@@ -65,8 +67,7 @@ class Character_Info:
     base_hp_scaling: list[float]
     base_atk_scaling: list[float]
     base_def_scaling: list[float]
-    max_forte: int
-    move_multipliers: dict[str, list[float]]
+    max_fe: int
     moves: dict[str, Move]
 
 class Weapon_Info:

--- a/util/db/model.py
+++ b/util/db/model.py
@@ -1,44 +1,92 @@
 
-from typing import Literal
+from typing import Union, Literal
 
-Weapon_Type = \
-    Literal['sword'] |\
-    Literal['broadblade'] |\
-    Literal['pistols'] |\
-    Literal['gauntlets'] |\
-    Literal['rectifier']
+Weapon_Type = Union[
+    Literal['sword'],
+    Literal['broadblade'],
+    Literal['pistols'],
+    Literal['gauntlets'],
+    Literal['rectifier'],
+]
 
-Element = \
-    Literal['spectro'] |\
-    Literal['havoc'] |\
-    Literal['glacio'] |\
-    Literal['fusion'] |\
-    Literal['aero'] |\
-    Literal['electro']
+Element = Union[
+    Literal['spectro'],
+    Literal['havoc'],
+    Literal['glacio'],
+    Literal['fusion'],
+    Literal['aero'],
+    Literal['electro'],
+]
 
-Forte_Type = \
-    Literal['a'] |\
-    Literal['e'] |\
-    Literal['f'] |\
-    Literal['r'] |\
-    Literal['i']
+Forte_Type = Union[
+    Literal['a'],
+    Literal['e'],
+    Literal['f'],
+    Literal['r'],
+    Literal['i'],
+]
 
-Move_Type = \
-    Literal['a'] |\
-    Literal['h'] |\
-    Literal['p'] |\
-    Literal['e'] |\
-    Literal['r'] |\
-    Literal['i'] |\
-    Literal['o']
+Move_Type = Union[
+    Literal['a'],
+    Literal['h'],
+    Literal['p'],
+    Literal['e'],
+    Literal['r'],
+    Literal['i'],
+    Literal['o'],
+]
 
-Substat = \
-    Literal['atk'] |\
-    Literal['hp'] |\
-    Literal['def'] |\
-    Literal['er'] |\
-    Literal['cr'] |\
-    Literal['cd']
+Substat = Union[
+    Literal['atk'],
+    Literal['hp'],
+    Literal['def'],
+    Literal['er'],
+    Literal['cr'],
+    Literal['cd'],
+]
+
+Stat = Union[
+    Literal['hp'],
+    Literal['atk'],
+    Literal['def'],
+    Literal['sta'], # Stamina
+    Literal['cr'], # Crit rate
+    Literal['cd'], # Crit damage
+    Literal['er'], # Energy regeneration
+    Literal['e_dmg_bonus'],
+    Literal['a_dmg_bonus'],
+    Literal['h_dmg_bonus'],
+    Literal['r_dmg_bonus'],
+    Literal['physical_dmg_bonus'],
+    Literal['glacio_dmg_bonus'],
+    Literal['fusion_dmg_bonus'],
+    Literal['electro_dmg_bonus'],
+    Literal['aero_dmg_bonus'],
+    Literal['spectro_dmg_bonus'],
+    Literal['havoc_dmg_bonus'],
+    Literal['physical_dmg_res'],
+    Literal['glacio_dmg_res'],
+    Literal['fusion_dmg_res'],
+    Literal['electro_dmg_res'],
+    Literal['aero_dmg_res'],
+    Literal['spectro_dmg_res'],
+    Literal['havoc_dmg_res'],
+    Literal['hb'] # Healing Bonus
+]
+
+class Buff_Condition:
+    move: None|str
+
+class Buff:
+    id: str
+    stat: Stat
+    amount: float
+    target: Literal['self']|Literal['enemy']
+    after: None|list[Buff_Condition]
+
+class Sequence_Node:
+    name: str
+    buff: None|Buff
 
 class Move:
     id: str
@@ -69,6 +117,7 @@ class Character_Info:
     base_def_scaling: list[float]
     max_fe: int
     moves: dict[str, Move]
+    res_chain: list[Sequence_Node]
 
 class Weapon_Info:
     id: str


### PR DESCRIPTION
* Added resonators' sequence nodes buffs.
* Rewrite the damage calculation formula in accordance with https://wutheringwaves.fandom.com/wiki/Damage
* Experimentally verified base resistance for all enemies in the game

**NOTE**: This PR introduces a regression, the json schemas have been disabled, all characters aside from spectro rover temporarily moved into a separate folder and removed from the database. This regression would need to be fixed by someone at some point after the change is merged.